### PR TITLE
fix: address feedback (Customer.Address model + token cache race) + DiscountExclVat

### DIFF
--- a/Rivr.Core/Models/Orders/Address.cs
+++ b/Rivr.Core/Models/Orders/Address.cs
@@ -1,0 +1,32 @@
+namespace Rivr.Core.Models.Orders;
+
+/// <summary>
+/// Represents a postal address.
+/// </summary>
+public class Address
+{
+    /// <summary>
+    /// The street address (line 1).
+    /// </summary>
+    public string? Street { get; set; }
+
+    /// <summary>
+    /// The street address (line 2).
+    /// </summary>
+    public string? Street2 { get; set; }
+
+    /// <summary>
+    /// The postal/zip code.
+    /// </summary>
+    public string? PostalCode { get; set; }
+
+    /// <summary>
+    /// The city.
+    /// </summary>
+    public string? City { get; set; }
+
+    /// <summary>
+    /// The ISO 3166-1 alpha-2 country code (e.g. "SE", "NO").
+    /// </summary>
+    public string? Country { get; set; }
+}

--- a/Rivr.Core/Models/Orders/CreateOrderRequest.cs
+++ b/Rivr.Core/Models/Orders/CreateOrderRequest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Rivr.Core.Models.Orders;
 
 /// <summary>
-/// The Payment Request Object is used in all payment request operations and the provided data object (body) should be in JSON format. 
+/// The Payment Request Object is used in all payment request operations and the provided data object (body) should be in JSON format.
 /// </summary>
 public class CreateOrderRequest
 {
@@ -36,7 +36,7 @@ public class CreateOrderRequest
     /// Computed total amount to pay, calculated from the order lines.
     /// </summary>
     /// <example>42000</example>
-    public int Amount => (int)OrderLines.Sum(o => o.Quantity * o.UnitPriceExclVat * (1 + o.VatPercentage / 100.0m));
+    public int Amount => (int)OrderLines.Sum(o => (o.Quantity * o.UnitPriceExclVat - o.DiscountExclVat) * (1 + o.VatPercentage / 100.0m));
 
     /// <summary>
     /// The Payer of the payment. This is the person that will pay for the payment request.

--- a/Rivr.Core/Models/Orders/Customer.cs
+++ b/Rivr.Core/Models/Orders/Customer.cs
@@ -21,6 +21,11 @@ public class Customer
     public string? LastName { get; set; }
 
     /// <summary>
+    /// The full name of the customer (typically <see cref="FirstName"/> and <see cref="LastName"/> combined).
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
     /// The email address of the customer.
     /// </summary>
     public string? Email { get; set; }
@@ -31,17 +36,7 @@ public class Customer
     public string? Phone { get; set; }
 
     /// <summary>
-    /// The street address of the customer.
+    /// The postal address of the customer.
     /// </summary>
-    public string? Address { get; set; }
-
-    /// <summary>
-    /// The city of the customer.
-    /// </summary>
-    public string? City { get; set; }
-
-    /// <summary>
-    /// The postal/zip code of the customer.
-    /// </summary>
-    public string? PostalCode { get; set; }
+    public Address? Address { get; set; }
 }

--- a/Rivr.Core/Models/Orders/OrderLine.cs
+++ b/Rivr.Core/Models/Orders/OrderLine.cs
@@ -48,19 +48,26 @@ public class OrderLine
     }
 
     /// <summary>
-    /// The price of the product or service excluding VAT
+    /// Optional discount amount excluding VAT applied to this line.
+    /// The discount is subtracted from the line total (UnitPriceExclVat * Quantity) before VAT is calculated.
+    /// </summary>
+    /// <example>0</example>
+    public decimal DiscountExclVat { get; set; }
+
+    /// <summary>
+    /// The unit price of the product or service including VAT
     /// </summary>
     public decimal UnitPriceInclVat => UnitPriceExclVat * (1 + VatPercentage / 100m);
 
     /// <summary>
-    /// The total price of the product or service including VAT
+    /// The total price of the product or service including VAT (after discount)
     /// </summary>
-    public decimal AmountInclVat => UnitPriceInclVat * Quantity;
+    public decimal AmountInclVat => AmountExclVat * (1 + VatPercentage / 100m);
 
     /// <summary>
-    /// The total price of the product or service excluding VAT
+    /// The total price of the product or service excluding VAT (after discount)
     /// </summary>
-    public decimal AmountExclVat => UnitPriceExclVat * Quantity;
+    public decimal AmountExclVat => UnitPriceExclVat * Quantity - DiscountExclVat;
 
     private decimal VatAmount => AmountInclVat - AmountExclVat;
 }

--- a/Rivr/MerchantClient.cs
+++ b/Rivr/MerchantClient.cs
@@ -31,6 +31,12 @@ public class MerchantClient : IMerchantOperations
     private string? _accessToken;
 
     /// <summary>
+    /// Safety margin subtracted from the token's reported lifetime when caching, to avoid races
+    /// where the token expires between the cache lookup and the request landing at the API.
+    /// </summary>
+    private static readonly TimeSpan TokenCacheSafetyMargin = TimeSpan.FromSeconds(60);
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MerchantClient"/> class.
     /// </summary>
     /// <param name="client"></param>
@@ -272,7 +278,7 @@ public class MerchantClient : IMerchantOperations
             var response = await _client.AuthHttpClient.PostAsJsonAsync("connect/token", merchantCredentials);
             await response.EnsureSuccessfulResponseAsync();
             var result = await response.DeserialiseAsync<TokenResponse>();
-            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(result.ExpiresIn);
+            entry.AbsoluteExpirationRelativeToNow = CalculateCacheLifetime(result.ExpiresIn);
             return result;
         });
 
@@ -282,6 +288,24 @@ public class MerchantClient : IMerchantOperations
         }
 
         _accessToken = response.AccessToken;
+    }
+
+    /// <summary>
+    /// Computes how long a token should be cached. Subtracts <see cref="TokenCacheSafetyMargin"/>
+    /// from the reported lifetime to avoid races where the token expires between the cache lookup
+    /// and the request landing at the API. Falls back to half the lifetime (minimum 1 second) when
+    /// the reported lifetime is shorter than the safety margin.
+    /// </summary>
+    private static TimeSpan CalculateCacheLifetime(int expiresInSeconds)
+    {
+        var lifetime = TimeSpan.FromSeconds(expiresInSeconds);
+        if (lifetime > TokenCacheSafetyMargin)
+        {
+            return lifetime - TokenCacheSafetyMargin;
+        }
+
+        var fallbackSeconds = Math.Max(1.0, expiresInSeconds / 2.0);
+        return TimeSpan.FromSeconds(fallbackSeconds);
     }
 
     static OrderRequestError[] Validate(CreateOrderRequest? createOrderRequest)

--- a/Rivr/MerchantClient.cs
+++ b/Rivr/MerchantClient.cs
@@ -271,7 +271,7 @@ public class MerchantClient : IMerchantOperations
         object merchantCredentials = _client.IsConfiguredForSingleMerchant
             ? new MerchantCredentialsRequest(_client.Credentials.Id, _client.Credentials.Secret)
             : new MerchantTokenRequest(_client.Credentials.Id, _client.Credentials.Secret, _merchantId);
-        
+
         var merchantCredentialsCacheKey = $"{nameof(Client)}-merchant-token-{_merchantId}";
         var response = await _client.MemoryCache.GetOrCreateAsync(merchantCredentialsCacheKey, async entry =>
         {
@@ -376,6 +376,24 @@ public class MerchantClient : IMerchantOperations
                 {
                     Message = "VatPercentage must be greater than or equal to 0",
                     PropertyName = nameof(orderLine.VatPercentage)
+                });
+            }
+
+            if (orderLine.DiscountExclVat < 0)
+            {
+                errorMessages.Add(new OrderRequestError
+                {
+                    Message = "DiscountExclVat must be greater than or equal to 0",
+                    PropertyName = nameof(orderLine.DiscountExclVat)
+                });
+            }
+
+            if (orderLine.DiscountExclVat > orderLine.UnitPriceExclVat * orderLine.Quantity)
+            {
+                errorMessages.Add(new OrderRequestError
+                {
+                    Message = "DiscountExclVat must not exceed the line total (UnitPriceExclVat * Quantity)",
+                    PropertyName = nameof(orderLine.DiscountExclVat)
                 });
             }
         }


### PR DESCRIPTION
## Summary

Tre relaterade fixar i klienten — två rapporterade av Sonett under deras POC mot `api.test.rivr.io`, samt befintlig WIP för rabattstöd som var halvt incheckad.

### 1. `Customer.Address` deserialiseras nu som objekt (BREAKING)

API:t returnerar `customer.address` som ett objekt:

```json
"address": { "street": null, "street2": null, "postalCode": null, "city": null, "country": null }
```

Klienten typade `Customer.Address` som `string?`, vilket gav `JsonException` på varje order-respons med en address. Fix:

- Ny `Address`-klass som matchar API:ts shape (`Street`, `Street2`, `PostalCode`, `City`, `Country`).
- `Customer.Address` ändrad från `string?` till `Address?`.
- `Customer.City` och `Customer.PostalCode` borttagna — de fanns aldrig på Customer-roten i wire-formatet, så de var alltid `null` efter deserialisering.
- `Customer.Name` tillagd (server returnerar redan `name`).

**Breaking change:** konsumenter som läser `Customer.Address` som sträng, eller `Customer.City` / `Customer.PostalCode` direkt, får kompileringsfel och måste flytta till `Customer.Address.Street` / `.City` / `.PostalCode`.

### 2. Token-cache med safety margin

Access token cachades exakt `expires_in` sekunder. Race-scenario: ett anrop precis innan cache-expiry kan plocka token från cache, bygga HTTP-request och få token att gå ut i flykten innan API:t tar emot den → spurious `401`.

- Drar 60s från cache-TTL (industristandard, t.ex. Stripe).
- För patologiskt korta tokens (≤ 60s) faller den tillbaka på halva livstiden med 1s-golv.

### 3. `DiscountExclVat` på `OrderLine`

Tillåter rabatter per orderrad. Subtraheras från linjetotalen innan VAT i `AmountExclVat` / `AmountInclVat`. `CreateOrderRequest.Amount` summerar nu med rabatt. Validering: ej negativ, ej större än `UnitPriceExclVat * Quantity`.

## Versionsbump

Innehåller breaking change → ska bumpas till `2.0.0` direkt efter merge med `rivr version bump major --auto` på `main`.

## Test plan

- [x] `dotnet build Rivr.sln` → success, 0 errors
- [ ] CI kör `Rivr.Test`-suiten
- [ ] Manuell verifiering av att Sonett kan deserialisera `Order` med address-objekt efter NuGet-uppdatering
